### PR TITLE
Switch from jsdoc-parse to jsdoc-to-markdown

### DIFF
--- a/lib/jsdoc-to-json-schema.js
+++ b/lib/jsdoc-to-json-schema.js
@@ -1,50 +1,36 @@
 var string2stream = require('string-to-stream');
-var stream2string = require('stream-to-string');
 var fs = require('fs-extra-promise');
-var jsDocParse = require('jsdoc-parse');
+var jsdoc2md = require('jsdoc-to-markdown');
 
 module.exports = function(input, output) {
 
     input = input || process.stdin;     // default stdin
     output = output || process.stdout;  // default stdout
 
-    // get input as a stream
-    return getInputAsStream(input).then(function(inputStream) {
+    return jsdoc2md.getTemplateData({ files: input, 'no-cache': true }).then((comments) => {
 
-        var parser = jsDocParse();
+        // build json schema from comments
+        var jsonSchema = buildJsonSchema(comments);
 
-        // send input into jsdoc-parser
-        inputStream.pipe(parser);
+        // if the output is a stream
+        if (output.write) {
 
-        // read jsdoc-parse output as json string
-        return stream2string(parser).then(function(comments) {
+            // send result to output stream
+            string2stream(JSON.stringify(jsonSchema)).pipe(output);
+        }
+        else {
 
-            // convert json string into JSON array of comments
-            var jsonComments = JSON.parse(comments);
+            // otherwise, write output to disk
+            fs.writeJsonAsync(output, jsonSchema, { spaces: 4 }).then(function(err) {
+                if (err) {
+                    console.error(err);
+                }
+            });
+        }
 
-            // build json schema from comments
-            var jsonSchema = buildJsonSchema(jsonComments);
+        // if no output object, return promise with JSON object
+        return Promise.resolve(jsonSchema);
 
-            // if the output is a stream
-            if (output.write) {
-
-                // send result to output stream
-                string2stream(JSON.stringify(jsonSchema)).pipe(output);
-            }
-            else {
-
-                // otherwise, write output to disk
-                fs.writeJsonAsync(output, jsonSchema, { spaces: 4 }).then(function(err) {
-                    if (err) {
-                        console.error(err);
-                    }
-                });
-            }
-
-            // if no output object, return promise with JSON object
-            return Promise.resolve(jsonSchema);
-
-        });
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "fs-extra-promise": "^0.3.1",
-    "jsdoc-parse": "^1.2.7",
-    "stream-to-string": "^1.0.1",
+    "jsdoc-to-markdown": "^6.0.1",
     "string-to-stream": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The jsdoc-parse version is quite old and has some vulnerabilities in its dependencies.   The author of jsdoc-parse, after bumping the version to 2.x, recommends using the `getTemplateData()` function from his package jsdoc-to-markdown instead of the lower level jsdocParse().  This patch replaces 'jsdocParse()' with a call to `jsdoc2md.getTemplateData()`.