### PR TITLE
Initial attempt to parse default values for arrays

### DIFF
--- a/lib/jsdoc-to-json-schema.js
+++ b/lib/jsdoc-to-json-schema.js
@@ -163,6 +163,20 @@ function buildJsonSchema(comments) {
                         schema.properties[block.name].uniqueItems = (value === 'true');
                     } break;
 
+                    /* customize on default */
+
+                    case 'default': {
+                        var blocktype = block.customTags.find(t => t.tag === 'schema.type').value || 'unknown';
+                        switch (blocktype) {
+                            case 'array': {
+                                schema.properties[block.name][tag] = (JSON.parse(value.replace('\\"', '""')));
+                            } break;
+                            default: {
+                                schema.properties[block.name][tag] = value;
+                            } break;
+                        }
+                    } break;
+
                     /* strings */
 
                     case 'extends':
@@ -176,7 +190,6 @@ function buildJsonSchema(comments) {
                     case 'enum':
                     case 'description':
                     case 'name':
-                    case 'default':
                     default: {
                         schema.properties[block.name][tag] = value;
                     } break;

--- a/test/data/test-singleton.js
+++ b/test/data/test-singleton.js
@@ -31,5 +31,16 @@ var product = {
      * @schema.minimum 0
      * @schema.required true
      */
-    price: ''
+    price: '',
+
+   /**
+    * @schema.title SKUs
+    * @schema.description SKUs of the product
+    * @schema.type array
+    * @schema.minItems 1
+    * @schema.items [integer]
+    * @schema.default [42, "anothersku"]
+    * @schema.required true
+    */
+    skus: []
 };

--- a/test/jsdoctojsonschema.spec.js
+++ b/test/jsdoctojsonschema.spec.js
@@ -48,6 +48,16 @@ describe('jsdoc-to-json-schema', function () {
             expect(schema.properties.price.minimum).toEqual(0);
             expect(schema.properties.price.required).toEqual(true);
 
+            // .skus property
+            expect(schema.properties.skus).toBeDefined();
+            expect(schema.properties.skus.type).toEqual('array');
+            expect(schema.properties.skus.title).toEqual('SKUs');
+            expect(schema.properties.skus.description).toEqual('SKUs of the product');
+            expect(schema.properties.skus.minItems).toEqual(1);
+            expect(schema.properties.skus.items).toEqual('[integer]');
+            expect(schema.properties.skus.default).toEqual([42, 'anothersku']);
+            expect(schema.properties.skus.required).toEqual(true);
+
             done();
         })
         .catch(function(err){


### PR DESCRIPTION
This patch allows default values to be specified for `array` types in jsdoc schema comments.